### PR TITLE
Illuminate problem in profiles spec

### DIFF
--- a/spec/features/profiles_spec.rb
+++ b/spec/features/profiles_spec.rb
@@ -9,7 +9,7 @@ describe "Visiting Profiles" do
     @post = associated_post(user: @user)
     @comment = Comment.new(user: @user, body: "Best comment ever by Juan!")
     allow(@comment).to receive(:send_favorite_emails)
-    @comment.save
+    @comment.save!
 
   end
 


### PR DESCRIPTION
I'm pretty sure this problem ultimately comes from an omission in the Bloc instructions and not anything you did wrong.  But ignoring that, here are some notes on investigating this problem:

----

----

If something behaves as expected in a "manual" test but fails in an automated (RSpec) test of the same behaviour, the first thing to examine is what conditions might be different between the setup of the "live" server and the setup of the test.

----

One (slightly tedious but occasionally necessary) way to investigate this would be to try to manually recreate the conditions of the spec as closely as possible:

* Clear the db (`rake db:migrate:reset` -- no seeding)

* Manually recreate the setup of the `before` block in `rails c` (ie, create an authenticated user, and associated post, etc), paying attention to the output (ie, the SQL debugging info, `commit transaction`, etc.)

* Manually recreate the steps of your test (visit the user path for the user you created; expect to see various things)

----

Another thing to do, and this is how I actually caught my first clue about the problem (since I was too lazy to start with the above), is do some really primitive debugging of some methods you know are being run through in the failing test.  I simply inserted a `p @comments` at the end of [`users#show`](https://github.com/luna-ramirezj/bloccit/blob/master/app/controllers/users_controller.rb#L17), cleared the terminal (⌘k), ran `rspec`, and saw:

```
....#<ActiveRecord::Associations::CollectionProxy []>
F.**...*....**..
```

`@comments` is empty.  So it's not the view's problem.

[`@comments = @user.comments`](https://github.com/luna-ramirezj/bloccit/blob/master/app/controllers/users_controller.rb#L17), so `@user.comments` is coming back empty to begin with.  Why?

> The "correct" way to investigate this, if you were doing super orthodox TDD and being personally judged by some kind of asshole, would be to write a [controller spec](http://www.relishapp.com/rspec/rspec-rails/docs/controller-specs), stating an expectation along the lines of `expect(assigns(:comments)).to_not be_empty`.  But "puts-debugging" is fine in many small cases.

----

At this point, I can think of 2 possibilities:

1. In the setup of the test, the comment is not being assigned to the (right?) user.  But it certainly looks like it is.

2. The comment is not being saved.  To investigate this, I made the small change that is the subject of this pull request.  Changing:

```ruby
@comment.save
```

to

```ruby
@comment.save!
```

Which, when I ran the spec again, pointed out the problem immediately.  It turns out to be a problem with the test setup, and not the app implementation.

----

The difference between these methods ([`save`](http://apidock.com/rails/ActiveRecord/Persistence/save) vs [`save!`](http://apidock.com/rails/ActiveRecord/Persistence/save%21)) is that if `save` fails, it will fail "silently".  It won't raise and exception, it will just return `false` and the program will continue on.  If there is a part of the program further down the line that is relying on the record having been saved successfully earlier, then that later part will be where the program fails, and any error messages you get will reflect the place where it failed, not the earlier problem which passed by silently.

If `save!` fails, it will raise an exception immediately, stopping the program at that point, and that exception will contain details about the record's failure to save.

It's a generally accepted practice to use `save` in a controller, and to decide how to continue (upon success or failure) by [checking its return value](https://github.com/luna-ramirezj/bloccit/blob/master/app/controllers/posts_controller.rb#L25).  We want, for example, an incomplete form resulting in an invalid record to display a nice error page to the user pointing out what they missed, and not to throw a "500 Internal Server Error" page at them.

> Note that it's possible to use exceptions and `rescue`/`rescue_from` to [achieve the same thing](https://github.com/luna-ramirezj/bloccit/blob/master/app/controllers/application_controller.rb#L9).  But `if...else` is simpler, and "idiomatic" in most simple cases.

But in a spec, `save!` (and its relatives [`create!`](http://apidock.com/rails/ActiveRecord/Associations/CollectionProxy/create%21) and [`update!`](http://apidock.com/rails/ActiveRecord/Persistence/update%21)) are more appropriate -- don't fail silently, if something fails to save, stop the show and immediately notify the developer of what and why.

----

----

So there are actually 2 errors in the instructions here: 1) using `save` instead of `save!` in a spec; and 2) the omission that you might discover after fixing 1).